### PR TITLE
DNM: trigger GLPK segfault

### DIFF
--- a/test/CBF_tests.jl
+++ b/test/CBF_tests.jl
@@ -10,9 +10,9 @@ const MOIFF = MOI.FileFormats
 import MOIPajarito
 
 function runtests(oa_solver, conic_solver)
-    @testset "iterative method" begin
-        run_cbf_tests(true, oa_solver, conic_solver)
-    end
+    # @testset "iterative method" begin
+    #     run_cbf_tests(true, oa_solver, conic_solver)
+    # end
     @testset "one tree method" begin
         run_cbf_tests(false, oa_solver, conic_solver)
     end
@@ -34,13 +34,14 @@ function run_cbf_tests(use_iter::Bool, oa_solver, conic_solver)
     MOI.set(model, MOI.RawOptimizerAttribute("time_limit"), 60)
     MOI.set(model, MOI.RawOptimizerAttribute("iteration_limit"), 100)
 
-    insts = ["sssd_strong_15_4", "exp_gatesizing", "exp_ising", "sdp_cardls"]
+    # insts = ["sssd_strong_15_4", "exp_gatesizing", "exp_ising", "sdp_cardls"]
+    insts = ["exp_gatesizing"]
     folder = joinpath(@__DIR__, "CBF")
 
     @testset "$inst" for inst in insts
-        if !use_iter && inst == "exp_gatesizing"
-            continue # TODO failing
-        end
+        # if !use_iter && inst == "exp_gatesizing"
+        #     continue # TODO failing
+        # end
         println(inst)
         file = joinpath(folder, string(inst, ".cbf"))
         run_cbf(model, file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,17 +36,17 @@ hypatia = MOI.OptimizerWithAttributes(
 
 println("starting Pajarito tests")
 Test.@testset "Pajarito tests" begin
-    println("starting MOI tests")
-    include("MOI_tests.jl")
-    Test.@testset "MOI tests" begin
-        TestMOI.runtests(glpk, hypatia)
-    end
+    # println("starting MOI tests")
+    # include("MOI_tests.jl")
+    # Test.@testset "MOI tests" begin
+    #     TestMOI.runtests(glpk, hypatia)
+    # end
 
-    println("starting JuMP tests")
-    include("JuMP_tests.jl")
-    Test.@testset "JuMP tests" begin
-        TestJuMP.runtests(glpk, hypatia)
-    end
+    # println("starting JuMP tests")
+    # include("JuMP_tests.jl")
+    # Test.@testset "JuMP tests" begin
+    #     TestJuMP.runtests(glpk, hypatia)
+    # end
 
     println("starting CBF tests")
     include("CBF_tests.jl")


### PR DESCRIPTION
runtests triggers a segfault from GLPK.
I did not see this error from any other instances and I did not get it when using Gurobi.

```
starting CBF tests
exp_gatesizing
glp_get_col_prim: j = 60; column number out of range
Error detected in file draft/glpapi06.c at line 774

signal (6): Abort trap: 6
in expression starting at /Users/coey/.julia/dev/MOIPajarito/test/myruntests.jl:47
__pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
pthread_kill at /usr/lib/system/libsystem_pthread.dylib (unknown line)
abort at /usr/lib/system/libsystem_c.dylib (unknown line)
errfunc at /Users/coey/.julia/artifacts/a8f69d41bc1a2b8d010db7eba6e1e89c06f026b9/lib/libglpk.40.dylib (unknown line)
glp_get_col_prim at /Users/coey/.julia/artifacts/a8f69d41bc1a2b8d010db7eba6e1e89c06f026b9/lib/libglpk.40.dylib (unknown line)
glp_get_col_prim at /Users/coey/.julia/packages/GLPK/mQmKc/src/gen/libglpk_api.jl:262 [inlined]
get at /Users/coey/.julia/packages/GLPK/mQmKc/src/MOI_wrapper/MOI_callbacks.jl:51 [inlined]
get at /Users/coey/.julia/packages/MathOptInterface/Li8RC/src/Bridges/bridge_optimizer.jl:1068 [inlined]
get at /Users/coey/.julia/packages/MathOptInterface/Li8RC/src/Bridges/bridge_optimizer.jl:1068
get at /Users/coey/.julia/packages/MathOptInterface/Li8RC/src/Utilities/cachingoptimizer.jl:845
unknown function (ip: 0x105235b5c)
_jl_invoke at /Users/coey/julia/src/gf.c:0 [inlined]
ijl_apply_generic at /Users/coey/julia/src/gf.c:2451
callback_value at /Users/coey/.julia/packages/JuMP/2IF9U/src/callbacks.jl:48
#169 at /Users/coey/.julia/packages/JuMP/2IF9U/src/callbacks.jl:66 [inlined]
value at /Users/coey/.julia/packages/JuMP/2IF9U/src/aff_expr.jl:292
callback_value at /Users/coey/.julia/packages/JuMP/2IF9U/src/callbacks.jl:65 [inlined]
_add_cut at /Users/coey/.julia/dev/MOIPajarito/src/JuMP_tools.jl:21
unknown function (ip: 0x105241335)
_jl_invoke at /Users/coey/julia/src/gf.c:0 [inlined]
ijl_apply_generic at /Users/coey/julia/src/gf.c:2451
add_cut at /Users/coey/.julia/dev/MOIPajarito/src/JuMP_tools.jl:11
add_cuts at /Users/coey/.julia/dev/MOIPajarito/src/JuMP_tools.jl:5 [inlined]
add_subp_cuts at /Users/coey/.julia/dev/MOIPajarito/src/cuts.jl:58
lazy_cb at /Users/coey/.julia/dev/MOIPajarito/src/algorithms.jl:177
```

error is from here: https://github.com/jump-dev/GLPK.jl/blob/485c89e10888de9fedf804cbaed7ad4f7fa648f1/src/MOI_wrapper/MOI_callbacks.jl#L51